### PR TITLE
Replace rosws update with vcs import

### DIFF
--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -762,7 +762,7 @@ function setup() {
                 "python3-apt"
             ];
             const python3Packages = [
-                "setuptools==49.3.0",
+                "setuptools!=50.0.0",
                 "colcon-bundle",
                 "colcon-ros-bundle"
             ];

--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -731,12 +731,8 @@ function fetchRosinstallDependencies() {
         let packages = [];
         // Download dependencies not in apt if .rosinstall exists
         try {
-            for (let workspace of ["robot_ws", "simulation_ws"]) {
-                if (fs.existsSync(path.join(workspace, '.rosinstall'))) {
-                    yield exec.exec("rosws", ["update", "-t", workspace]);
-                }
-            }
             if (fs.existsSync(path.join(WORKSPACE_DIRECTORY, '.rosinstall'))) {
+                yield exec.exec("vcs", ["import", "--input", ".rosinstall"], getExecOptions());
                 yield exec.exec("colcon", ["list", "--names-only"], getExecOptions(colconListAfter));
                 const packagesAfter = colconListAfter.stdout.split("\n");
                 packagesAfter.forEach(packageName => {

--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -762,7 +762,7 @@ function setup() {
                 "python3-apt"
             ];
             const python3Packages = [
-                "setuptools",
+                "setuptools==49.3.0",
                 "colcon-bundle",
                 "colcon-ros-bundle"
             ];

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -101,7 +101,7 @@ async function setup() {
     ];
 
     const python3Packages = [
-      "setuptools",
+      "setuptools==49.3.0",
       "colcon-bundle",
       "colcon-ros-bundle"
     ];

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -101,7 +101,7 @@ async function setup() {
     ];
 
     const python3Packages = [
-      "setuptools==49.3.0",
+      "setuptools!=50.0.0",
       "colcon-bundle",
       "colcon-ros-bundle"
     ];

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -70,12 +70,8 @@ async function fetchRosinstallDependencies(): Promise<string[]> {
   let packages: string[] = [];
   // Download dependencies not in apt if .rosinstall exists
   try {
-    for (let workspace of ["robot_ws", "simulation_ws"]) {
-      if (fs.existsSync(path.join(workspace, '.rosinstall'))) {
-        await exec.exec("rosws", ["update", "-t", workspace]);
-      }
-    }
     if (fs.existsSync(path.join(WORKSPACE_DIRECTORY, '.rosinstall'))) {
+      await exec.exec("vcs", ["import", "--input", ".rosinstall"], getExecOptions());
       await exec.exec("colcon", ["list", "--names-only"], getExecOptions(colconListAfter));
       const packagesAfter = colconListAfter.stdout.split("\n");
       packagesAfter.forEach(packageName => {


### PR DESCRIPTION
As `rosws` is deprecated, this PR replaces `rosws update` with `vcs import`.

Tested for both ROS1 (Kinetic & Melodic) and ROS2 (Dashing).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
