### PR TITLE
Undo setuptools blacklist

### DIFF
--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -762,7 +762,7 @@ function setup() {
                 "python3-apt"
             ];
             const python3Packages = [
-                "setuptools!=50.0.0",
+                "setuptools",
                 "colcon-bundle",
                 "colcon-ros-bundle"
             ];

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -101,7 +101,7 @@ async function setup() {
     ];
 
     const python3Packages = [
-      "setuptools!=50.0.0",
+      "setuptools",
       "colcon-bundle",
       "colcon-ros-bundle"
     ];


### PR DESCRIPTION
[Latest version (50.0.2)](https://github.com/pypa/setuptools/releases/tag/v50.0.2) of setuptools included the bug fix, thus reverting the change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
