### PR TITLE
Fix bug where rosdep sources are not updated correctly

### DIFF
--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -803,11 +803,11 @@ function setup_gazebo9() {
             if (ROS_DISTRO == "kinetic") {
                 const gazebo9_rosdep_file = "/etc/ros/rosdep/sources.list.d/00-gazebo9.list";
                 yield exec.exec("sudo", ["rm", "-f", gazebo9_rosdep_file]);
-                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" | sudo tee ${gazebo9_rosdep_file}`]);
-                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" | sudo tee ${gazebo9_rosdep_file}`]);
-                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" | sudo tee ${gazebo9_rosdep_file}`]);
-                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" | sudo tee ${gazebo9_rosdep_file}`]);
-                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" | sudo tee ${gazebo9_rosdep_file}`]);
+                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" | sudo tee -a ${gazebo9_rosdep_file}`]);
+                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" | sudo tee -a ${gazebo9_rosdep_file}`]);
+                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" | sudo tee -a ${gazebo9_rosdep_file}`]);
+                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" | sudo tee -a ${gazebo9_rosdep_file}`]);
+                yield exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" | sudo tee -a ${gazebo9_rosdep_file}`]);
                 yield exec.exec("rosdep", ["update"]);
             }
         }

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -150,11 +150,11 @@ async function setup_gazebo9() {
     if (ROS_DISTRO == "kinetic") {
       const gazebo9_rosdep_file = "/etc/ros/rosdep/sources.list.d/00-gazebo9.list";
       await exec.exec("sudo", ["rm", "-f", gazebo9_rosdep_file]);
-      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" | sudo tee ${gazebo9_rosdep_file}`]);
-      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" | sudo tee ${gazebo9_rosdep_file}`]);
-      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" | sudo tee ${gazebo9_rosdep_file}`]);
-      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" | sudo tee ${gazebo9_rosdep_file}`]);
-      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" | sudo tee ${gazebo9_rosdep_file}`]);
+      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/gazebo.yaml" | sudo tee -a ${gazebo9_rosdep_file}`]);
+      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/indigo.yaml indigo" | sudo tee -a ${gazebo9_rosdep_file}`]);
+      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/jade.yaml jade" | sudo tee -a ${gazebo9_rosdep_file}`]);
+      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/kinetic.yaml kinetic" | sudo tee -a ${gazebo9_rosdep_file}`]);
+      await exec.exec("bash", ["-c", `echo "yaml https://github.com/osrf/osrf-rosdep/raw/master/gazebo9/releases/lunar.yaml lunar" | sudo tee -a ${gazebo9_rosdep_file}`]);
       await exec.exec("rosdep", ["update"]);
     }
    } catch (error) {


### PR DESCRIPTION
*Description of changes:*

We found that Gazebo 7 was still being installed even though we attempted to add the Gazebo 9 `apt` and `rosdep` sources. It turns out that the new rosdistro YAML sources weren't being appended, but being overwritten.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
