### PR TITLE
Bug fix: fail the action when catching exception from cli command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: 'kenvink/ros1-test-bad-dep-git-url'
+        ref: kenvink/ros1-test-bad-dep-git-url
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: ros1
+        ref: kenvink/ros1-test-dep-bad-git-url
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: kenvink/ros1-test-bad-dep-git-url
+        ref: 'kenvink/ros1-test-bad-dep-git-url'
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: kenvink/ros1-test-dep-bad-git-url
+        ref: kenvink/ros1-test-bad-dep-git-url
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: 'kenvink/ros1-test-bad-dep-git-url'
+        ref: ros1
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -66,8 +66,8 @@ async function getSampleAppVersion() : Promise<string> {
          "find ../robot_ws -name package.xml -exec grep -Po '(?<=<version>)[^\\s<>]*(?=</version>)' {} +"],
       getWorkingDirExecOptions(grepAfter));
     version = grepAfter.stdout.trim();
-  } catch(err) {
-    console.error(err);
+  } catch(error) {
+    core.setFailed(error.message);
   }
   return Promise.resolve(version);
 }
@@ -93,8 +93,8 @@ async function fetchRosinstallDependencies(): Promise<string[]> {
         packages.push(packageName.trim());
       });
     }
-  } catch(err) {
-    console.error(err);
+  } catch(error) {
+    core.setFailed(error.message);
   }
   return Promise.resolve(packages);
 }


### PR DESCRIPTION
- We need to fail the action whenever there is an exception, we already did that in multiple places except in fetchRosinstallDependencies and getSampleAppVersion

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
