### PR TITLE
Adding git-secrets-scan-action

### DIFF
--- a/git-secrets-scan-action/Dockerfile
+++ b/git-secrets-scan-action/Dockerfile
@@ -6,10 +6,6 @@ LABEL "com.github.actions.description"="Scan for secrets in your repo CI"
 LABEL "com.github.actions.icon"="trending-up"
 LABEL "com.github.actions.color"="blue"
 
-ENV AWSCLI_VERSION='1.16.232'
-
-RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
-
 # Setup environment to install and run git-secrets
 RUN apk update
 RUN apk add bash 

--- a/git-secrets-scan-action/Dockerfile
+++ b/git-secrets-scan-action/Dockerfile
@@ -1,0 +1,23 @@
+ 
+FROM python:3.7-alpine
+
+LABEL "com.github.actions.name"="git-secrets-scan-action"
+LABEL "com.github.actions.description"="Scan for secrets in your repo CI"
+LABEL "com.github.actions.icon"="trending-up"
+LABEL "com.github.actions.color"="blue"
+
+ENV AWSCLI_VERSION='1.16.232'
+
+RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
+
+# Setup environment to install and run git-secrets
+RUN apk update
+RUN apk add bash 
+RUN apk add --update alpine-sdk
+RUN apk add --update git
+RUN apk add --update ncurses
+
+ADD entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/git-secrets-scan-action/LICENSE.md
+++ b/git-secrets-scan-action/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Jake Jarvis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/git-secrets-scan-action/LICENSE.md
+++ b/git-secrets-scan-action/LICENSE.md
@@ -1,21 +1,175 @@
-MIT License
 
-Copyright (c) 2019 Jake Jarvis
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -29,6 +29,9 @@ jobs:
       uses: actions/checkout@v1
     - name: scan-git-secrets
       uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.0
+      with:
+        path: my-repo-path
+
 ```
 
 ### Input Variables

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -17,7 +17,7 @@ The action checks for common AWS patterns and ensures that keys present in ~/.aw
 Place in a `.yml` file such as this one in your `.github/workflows` folder. [Refer to the documentation on workflow YAML syntax here.](https://help.github.com/en/articles/workflow-syntax-for-github-actions)
 
 ```
-name: Sync Bucket
+name: Scan Secrets
 on: push
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v1
     - name: scan-git-secrets
       uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.0
 ```

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -2,7 +2,7 @@
 
 This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) and [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public. 
 
-The action checks for common AWS patterns and ensures that keys present in ~/.aws/credentials are not found in any commit. The following checks are added:
+The action performs `--scan-history` for all the repo revisions/commits and checks for common AWS patterns and ensures that keys present in ~/.aws/credentials are not found in any commit. The following checks are added:
 
 * AWS Access Key IDs via (A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
 * AWS Secret Access Key assignments via ":" or "=" surrounded by optional quotes

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -38,14 +38,4 @@ jobs:
 
 | Key | Value | Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
-| `path` | Applicable only if you are using actions/checkout@v2. Refers to the relative path under $GITHUB_WORKSPACE where the repository is checked-out. | `string` | **No** |
-
-
-### Environment Variables
-
-| Key | Value | Type | Required |
-| ------------- | ------------- | ------------- | ------------- |
-| `GITHUB_WORKSPACE` | The GitHub workspace directory path. The workspace directory contains a subdirectory with a copy of your repository if your workflow uses the actions/checkout action. If you don't use the actions/checkout action, the directory will be empty. For example, /home/runner/work/my-repo-name/my-repo-name. This variable is set by GH actions. | `env` | **Yes** |
-
-
-
+| `path` | Refers to the relative path under the current working directory or an absolute path to where the repository is checked-out. If not set, repository is assumed to be checked-out under the current working directory. | `string` | **No** |

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -1,6 +1,6 @@
 # GitHub Action to `git secrets --scan` in your CI  🔄
 
-This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) and [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public. 
+This simple action uses [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public. 
 
 The action performs `--scan-history` for all the repo revisions/commits and checks for common AWS patterns and ensures that keys present in ~/.aws/credentials are not found in any commit. The following checks are added:
 

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -1,0 +1,35 @@
+# GitHub Action to `git secrets --scan` in your CI  🔄
+
+This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) and [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public.
+
+
+## Usage
+
+### `workflow.yml` Example
+
+Place in a `.yml` file such as this one in your `.github/workflows` folder. [Refer to the documentation on workflow YAML syntax here.](https://help.github.com/en/articles/workflow-syntax-for-github-actions)
+
+```
+name: Sync Bucket
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: scan-git-secrets
+      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.0
+```
+
+
+### Environment Variables
+
+| Key | Value | Type | Required |
+| ------------- | ------------- | ------------- | ------------- |
+| `GITHUB_WORKSPACE` | The GitHub workspace directory path. The workspace directory contains a subdirectory with a copy of your repository if your workflow uses the actions/checkout action. If you don't use the actions/checkout action, the directory will be empty. For example, /home/runner/work/my-repo-name/my-repo-name. This variable is set by GH actions. | `env` | **Yes** |
+
+
+

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -1,7 +1,14 @@
 # GitHub Action to `git secrets --scan` in your CI  🔄
 
-This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) and [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public.
+This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) and [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public. 
 
+The action checks for common AWS patterns and ensures that keys present in ~/.aws/credentials are not found in any commit. The following checks are added:
+
+* AWS Access Key IDs via (A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
+* AWS Secret Access Key assignments via ":" or "=" surrounded by optional quotes
+* AWS account ID assignments via ":" or "=" surrounded by optional quotes
+* Allowed patterns for example AWS keys (AKIAIOSFODNN7EXAMPLE and wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)
+* Known credentials from ~/.aws/credentials
 
 ## Usage
 

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -31,6 +31,12 @@ jobs:
       uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.0
 ```
 
+### Input Variables
+
+| Key | Value | Type | Required |
+| ------------- | ------------- | ------------- | ------------- |
+| `path` | Relative path under $GITHUB_WORKSPACE to place the repository | `string` | **No** |
+
 
 ### Environment Variables
 

--- a/git-secrets-scan-action/README.md
+++ b/git-secrets-scan-action/README.md
@@ -38,7 +38,7 @@ jobs:
 
 | Key | Value | Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
-| `path` | Relative path under $GITHUB_WORKSPACE to place the repository | `string` | **No** |
+| `path` | Applicable only if you are using actions/checkout@v2. Refers to the relative path under $GITHUB_WORKSPACE where the repository is checked-out. | `string` | **No** |
 
 
 ### Environment Variables

--- a/git-secrets-scan-action/action.yml
+++ b/git-secrets-scan-action/action.yml
@@ -4,8 +4,7 @@ inputs:
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
     required: true
-    default: '.'
-outputs:
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/git-secrets-scan-action/action.yml
+++ b/git-secrets-scan-action/action.yml
@@ -2,7 +2,7 @@ name: 'Scan with git-secrets'
 description: 'Scan repository with git-secrets'
 inputs:
   path:
-    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    description: 'Refers to the relative path under the current working directory or an absolute path to where the repository is checked-out'
     required: true
     default: '.'
 runs:

--- a/git-secrets-scan-action/action.yml
+++ b/git-secrets-scan-action/action.yml
@@ -1,0 +1,13 @@
+name: 'Scan with git-secrets'
+description: 'Scan repository with git-secrets'
+inputs:
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    required: true
+    default: ''
+outputs:
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}

--- a/git-secrets-scan-action/action.yml
+++ b/git-secrets-scan-action/action.yml
@@ -4,7 +4,7 @@ inputs:
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
     required: true
-    default: ''
+    default: '.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/git-secrets-scan-action/action.yml
+++ b/git-secrets-scan-action/action.yml
@@ -4,7 +4,7 @@ inputs:
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
     required: true
-    default: ''
+    default: '.'
 outputs:
 runs:
   using: 'docker'

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -12,13 +12,13 @@ git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make i
 LOCAL_REPO_PATH=${GITHUB_WORKSPACE}/$1
 ABS_REPO_PATH=/$1
 
-if [[ -d "${ABS_REPO_PATH}"]]; then
+if [[ -d "${ABS_REPO_PATH}" ]]; then
     cd ${ABS_REPO_PATH}
     REPO_PATH=${ABS_REPO_PATH}
 elif [[ -z "${GITHUB_WORKSPACE}" ]]; then
     echo "Required variable GITHUB_WORKSPACE not set."
     exit 1
-elif [[ ! -z "${GITHUB_WORKSPACE}" && -d "${LOCAL_REPO_PATH}"]]; then
+elif [[ ! -z "${GITHUB_WORKSPACE}" && -d "${LOCAL_REPO_PATH}" ]]; then
     cd ${LOCAL_REPO_PATH}
     REPO_PATH=${LOCAL_REPO_PATH}
 else

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -7,7 +7,7 @@ cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
 # Check if GITHUB_WORKSPACE is set
-if [[ -z "${DEPLOY_ENV}" ]]; then
+if [ -z "${GITHUB_WORKSPACE}" ]; then
     echo "Required env variable GITHUB_WORKSPACE not set."
     exit 1
 fi
@@ -15,7 +15,7 @@ fi
 cd ${GITHUB_WORKSPACE}
 
 # Check if repository is checked-out using actions/checkout
-if [ -z "$(ls -A ) ."]; then
+if [ -z "$(ls -A .)" ]; then
     echo "Workspace is empty. Did you checkout the repository using actions/checkout?"
     exit 1
 fi

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+# Clone and install git-secrets from source
+cd ${HOME}
+git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
+
+cd ${GITHUB_WORKSPACE}
+
+# Register git-secrets in the workspace repo
+git secrets --install
+git secrets --register-aws
+
+set +e
+
+# Scan for secrets being committed
+if git secrets --scan 2>&1 >/dev/null | grep -q "[ERROR]"; then
+    # Secrets exist. Echo error and exit with code 1
+    _secret_exists=1
+    echo "Secrets exist in your commits. Please rectify and re-commit."
+    echo "::set-output name=secret_exists::$_secret_exists"
+    exit 1
+else
+    # Secrets don't exist. Exit with code 0
+    _secret_exists=0
+    echo "No secrets exist in your commits."
+    echo "::set-output name=secret_exists::$_secret_exists"
+    exit 0
+fi 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -2,21 +2,23 @@
 
 set -e
 
+REPO_PATH=${GITHUB_WORKSPACE}/$1
+
 # Clone and install git-secrets from source
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
 # Check if GITHUB_WORKSPACE is set and points to a valid directory
-if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
-    echo "Required env variable GITHUB_WORKSPACE not set or does not point to a valid directory."
+if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${REPO_PATH}" ]]; then
+    echo "Required env variable GITHUB_WORKSPACE not set or ${REPO_PATH} does not point to a valid directory."
     exit 1
 fi
 
-cd ${GITHUB_WORKSPACE}
+cd ${REPO_PATH}
 
 # Check if repository is checked-out using actions/checkout
 if [ -z "$(ls -A .)" ]; then
-    echo "Workspace is empty. Did you checkout the repository using actions/checkout?"
+    echo "${REPO_PATH} is empty. Did you checkout the repository using actions/checkout?"
     exit 1
 fi
 
@@ -31,7 +33,7 @@ git secrets --scan-history 2> secret_logs.txt
 cat secret_logs.txt | grep -q "[ERROR]";
 _secret_exists=$?
 
-if [ $_secret_exists == 0 ]; then
+if [ ${_secret_exists} == 0 ]; then
     # Secrets exist. Echo error and exit with code 1
     echo "Secrets exist in your commits. Please rectify the bad commits and re-commit."
     cat secret_logs.txt

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -10,7 +10,7 @@ git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make i
 # In actions/checkout@v2, is a path relative to ${GITHUB_WORKSPACE} where the repo will get checked-out.
 # Hence, we check the provided path is valid as an absolute path or as an relative path.
 LOCAL_REPO_PATH=${GITHUB_WORKSPACE}/$1
-ABS_REPO_PATH=$1
+ABS_REPO_PATH=/$1
 
 if [[ -d "${ABS_REPO_PATH}"]]; then
     cd ${ABS_REPO_PATH}

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -6,26 +6,26 @@ set -e
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
-# In actions/checkout@v1, path is the absolute path to where the repo will get checked-out.
-# In actions/checkout@v2, is a path relative to ${GITHUB_WORKSPACE} where the repo will get checked-out.
+# In actions/checkout@v1, input variable `path` is undefined and the repo is checked-out in ${GITHUB_WORKSPACE}.
+# In actions/checkout@v2, input variable `path` is a path relative to ${GITHUB_WORKSPACE} where the repo will get checked-out.
 # Hence, we check the provided path is valid as an absolute path or as an relative path.
-LOCAL_REPO_PATH=${GITHUB_WORKSPACE}
-ABS_REPO_PATH=/$1
+V1_REPO_PATH=${GITHUB_WORKSPACE}
+V2_REPO_PATH=${GITHUB_WORKSPACE}/$1
 
-if [[ -d "${ABS_REPO_PATH}" ]]; then
-    cd ${ABS_REPO_PATH}
-    REPO_PATH=${ABS_REPO_PATH}
+if [[ -d "${V2_REPO_PATH}" ]]; then
+    cd ${V2_REPO_PATH}
+    REPO_PATH=${V2_REPO_PATH}
 elif [[ -z "${GITHUB_WORKSPACE}" ]]; then
     echo "Required variable GITHUB_WORKSPACE not set."
     exit 1
-elif [[ ! -z "${GITHUB_WORKSPACE}" && -d "${LOCAL_REPO_PATH}" ]]; then
-    cd ${LOCAL_REPO_PATH}
-    REPO_PATH=${LOCAL_REPO_PATH}
+elif [[ ! -z "${GITHUB_WORKSPACE}" && -d "${V1_REPO_PATH}" ]]; then
+    cd ${V1_REPO_PATH}
+    REPO_PATH=${V1_REPO_PATH}
 else
-    echo "Neither ${ABS_REPO_PATH} nor ${LOCAL_REPO_PATH} point to a valid directory."
+    echo "Neither ${V1_REPO_PATH} nor ${V2_REPO_PATH} point to a valid directory."
     exit 1
 fi
-# Check if repository is checked-out using actions/checkout
+# Check if repository is checked-out using actions/checkout and is not empty
 if [ -z "$(ls -A .)" ]; then
     echo "${REPO_PATH} is empty. Did you checkout the repository using actions/checkout?"
     exit 1

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -6,28 +6,25 @@ set -e
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
-# In actions/checkout@v1, input variable `path` is undefined and the repo is checked-out in ${GITHUB_WORKSPACE}.
-# In actions/checkout@v2, input variable `path` is a path relative to ${GITHUB_WORKSPACE} where the repo will get checked-out.
-# Hence, we check the provided path is valid as an absolute path or as an relative path.
-V1_REPO_PATH=${GITHUB_WORKSPACE}
-V2_REPO_PATH=${GITHUB_WORKSPACE}/$1
-
-if [[ -d "${V2_REPO_PATH}" ]]; then
-    cd ${V2_REPO_PATH}
-    REPO_PATH=${V2_REPO_PATH}
-elif [[ -z "${GITHUB_WORKSPACE}" ]]; then
+# Check if $GITHUB_WORKSPACE is set
+if [[ -z "${GITHUB_WORKSPACE}" ]]; then
     echo "Required variable GITHUB_WORKSPACE not set."
     exit 1
-elif [[ ! -z "${GITHUB_WORKSPACE}" && -d "${V1_REPO_PATH}" ]]; then
-    cd ${V1_REPO_PATH}
-    REPO_PATH=${V1_REPO_PATH}
+fi 
+
+if [ $1 ]; then
+    # actions/checkout@v2
+    REPO_PATH=${GITHUB_WORKSPACE}/$1
 else
-    echo "Neither ${V1_REPO_PATH} nor ${V2_REPO_PATH} point to a valid directory."
-    exit 1
+    # actions/checkout@v1
+    REPO_PATH=${GITHUB_WORKSPACE}
 fi
-# Check if repository is checked-out using actions/checkout and is not empty
-if [ -z "$(ls -A .)" ]; then
-    echo "${REPO_PATH} is empty. Did you checkout the repository using actions/checkout?"
+
+# Check if repository is checked-out and repo directory is not empty
+if [[ -d "${REPO_PATH}" && ! -z "$(ls -A ${REPO_PATH})"]]; then
+    cd ${REPO_PATH}
+else
+    echo "${REPO_PATH} does not point to a valid directory or is empty. Please check usage of $path input variable based on which version of actions/checkout you have used."
     exit 1
 fi
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -6,12 +6,11 @@ set -e
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
-# Check if GITHUB_WORKSPACE is set
+# Check if GITHUB_WORKSPACE is set and points to a valid directory
 if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
     echo "Required env variable GITHUB_WORKSPACE not set or does not point to a valid directory."
     exit 1
 fi
-
 
 cd ${GITHUB_WORKSPACE}
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -7,10 +7,11 @@ cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
 # Check if GITHUB_WORKSPACE is set
-if [ -z "${GITHUB_WORKSPACE}" ]; then
-    echo "Required env variable GITHUB_WORKSPACE not set."
+if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
+    echo "Required env variable GITHUB_WORKSPACE not set or does not point to a valid directory."
     exit 1
 fi
+
 
 cd ${GITHUB_WORKSPACE}
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -7,7 +7,7 @@ cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
 # Check if GITHUB_WORKSPACE is set
-if [[ -z "${DEPLOY_ENV}" ]]
+if [[ -z "${DEPLOY_ENV}" ]]; then
     echo "Required env variable GITHUB_WORKSPACE not set."
     exit 1
 fi

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -2,29 +2,21 @@
 
 set -e
 
-# Clone and install git-secrets from source
+WORK_DIR=`pwd`
+
+# Clone into $HOME dir and install git-secrets from source
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
-# Check if $GITHUB_WORKSPACE is set
-if [[ -z "${GITHUB_WORKSPACE}" ]]; then
-    echo "Required variable GITHUB_WORKSPACE not set."
-    exit 1
-fi 
+# Change directory to the default workspace directory. 
+cd ${WORK_DIR}
 
-if [ $1 ]; then
-    # actions/checkout@v2
-    REPO_PATH=${GITHUB_WORKSPACE}/$1
+# Check if repo directory exists and the repository is checked-out. If yes, change current directory to repo directory.
+# $1(path) defaults to '.' and can be a path relative to WORK_DIR or can also be an absolute path as well.
+if [[ -d "$1" && ! -z "$(ls -A $1)" ]]; then
+    cd $1
 else
-    # actions/checkout@v1
-    REPO_PATH=${GITHUB_WORKSPACE}
-fi
-
-# Check if repository is checked-out and repo directory is not empty
-if [[ -d "${REPO_PATH}" && ! -z "$(ls -A ${REPO_PATH})" ]]; then
-    cd ${REPO_PATH}
-else
-    echo "${REPO_PATH} does not point to a valid directory or is empty. Please check the README for the usage of path input variable based on which version of actions/checkout you have used."
+    echo "the provided path variable does not point to a valid directory or is empty. Does the path input variable point to the directory where your repo is checked-out?"
     exit 1
 fi
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -21,10 +21,10 @@ else
 fi
 
 # Check if repository is checked-out and repo directory is not empty
-if [[ -d "${REPO_PATH}" && ! -z "$(ls -A ${REPO_PATH})"]]; then
+if [[ -d "${REPO_PATH}" && ! -z "$(ls -A ${REPO_PATH})" ]]; then
     cd ${REPO_PATH}
 else
-    echo "${REPO_PATH} does not point to a valid directory or is empty. Please check usage of $path input variable based on which version of actions/checkout you have used."
+    echo "${REPO_PATH} does not point to a valid directory or is empty. Please check the README for the usage of path input variable based on which version of actions/checkout you have used."
     exit 1
 fi
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -9,7 +9,7 @@ git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make i
 # In actions/checkout@v1, path is the absolute path to where the repo will get checked-out.
 # In actions/checkout@v2, is a path relative to ${GITHUB_WORKSPACE} where the repo will get checked-out.
 # Hence, we check the provided path is valid as an absolute path or as an relative path.
-LOCAL_REPO_PATH=${GITHUB_WORKSPACE}/$1
+LOCAL_REPO_PATH=${GITHUB_WORKSPACE}
 ABS_REPO_PATH=/$1
 
 if [[ -d "${ABS_REPO_PATH}" ]]; then

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -6,7 +6,19 @@ set -e
 cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
+# Check if GITHUB_WORKSPACE is set
+if [[ -z "${DEPLOY_ENV}" ]]
+    echo "Required env variable GITHUB_WORKSPACE not set."
+    exit 1
+fi
+
 cd ${GITHUB_WORKSPACE}
+
+# Check if repository is checked-out using actions/checkout
+if [ -z "$(ls -A ) ."]; then
+    echo "Workspace is empty. Did you checkout the repository using actions/checkout?"
+    exit 1
+fi
 
 # Register git-secrets in the workspace repo
 git secrets --install

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -9,8 +9,13 @@ cd ${HOME}
 git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && make install 
 
 # Check if GITHUB_WORKSPACE is set and points to a valid directory
-if [[ -z "${GITHUB_WORKSPACE}" || ! -d "${REPO_PATH}" ]]; then
-    echo "Required env variable GITHUB_WORKSPACE not set or ${REPO_PATH} does not point to a valid directory."
+if [[ -z "${GITHUB_WORKSPACE}"]]; then
+    echo "Required env variable GITHUB_WORKSPACE not set."
+    exit 1
+fi
+
+if [[ ! -d "${REPO_PATH}" ]]; then
+    echo "${REPO_PATH} does not point to a valid directory."
     exit 1
 fi
 

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -32,12 +32,12 @@ cat secret_logs.txt | grep -q "[ERROR]";
 _secret_exists=$?
 
 # Show git secret err message helping user to rectify
-if [! -s diff.txt ]; then
+if [ ! -s diff.txt ]; then
     cat secret_logs.txt
     rm -rf secret_logs.txt
 fi
 
-if [_secret_exists == 0]; then
+if [ $_secret_exists == 0 ]; then
     # Secrets exist. Echo error and exit with code 1
     echo "Secrets exist in your commits. Please rectify and re-commit."
     exit 1

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -31,15 +31,11 @@ git secrets --scan-history 2> secret_logs.txt
 cat secret_logs.txt | grep -q "[ERROR]";
 _secret_exists=$?
 
-# Show git secret err message helping user to rectify
-if [ ! -s diff.txt ]; then
-    cat secret_logs.txt
-    rm -rf secret_logs.txt
-fi
-
 if [ $_secret_exists == 0 ]; then
     # Secrets exist. Echo error and exit with code 1
-    echo "Secrets exist in your commits. Please rectify and re-commit."
+    echo "Secrets exist in your commits. Please rectify the bad commits and re-commit."
+    cat secret_logs.txt
+    rm -rf secret_logs.txt
     exit 1
 else
     # Secrets don't exist. Exit with code 0

--- a/git-secrets-scan-action/entrypoint.sh
+++ b/git-secrets-scan-action/entrypoint.sh
@@ -29,7 +29,7 @@ set +e
 # Scan entire history for secrets being committed (secrets can be committed in earlier commits which also need to be pointed out here)
 git secrets --scan-history 2> secret_logs.txt
 cat secret_logs.txt | grep -q "[ERROR]";
-_secret_exists = $?
+_secret_exists=$?
 
 # Show git secret err message helping user to rectify
 if [! -s diff.txt ]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This simple action uses [git secrets](https://github.com/awslabs/git-secrets) to scan your repository for secrets being commited to public.

*Tests*
Tested on personal forks with/without committing fake aws_credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
