### PR TITLE
Add colcon bundle retry

### DIFF
--- a/robomaker-sample-app-ci/action.yml
+++ b/robomaker-sample-app-ci/action.yml
@@ -13,6 +13,10 @@ inputs:
   generate-sources:
     description: 'Whether or not to generate sources.zip and sources.tar.gz files [true|false]'
     default: false
+  colcon-bundle-retries:
+    description: 'Number of times colcon bundle should be re-tried with exponentail backoff in case of failure [0-9]'
+    default: 0
+
 outputs:
   ros-distro:
     description: 'Distribution of ROS to use [kinetic|melodic|dashing]'

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -12,6 +12,13 @@ const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
 const GENERATE_SOURCES = core.getInput('generate-sources');
 let PACKAGES = "none"
 const ROS_ENV_VARIABLES: any = {};
+let COLCON_BUNDLE_RETRIES = core.getInput('colcon-bundle-retries');
+const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
+const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
 
 async function loadROSEnvVariables() {
   const options = {
@@ -184,7 +191,6 @@ async function prepare_sources() {
 async function build() {
   try {
     await exec.exec("rosdep", ["install", "--from-paths", ".", "--ignore-src", "-r", "-y", "--rosdistro", ROS_DISTRO], getWorkingDirExecOptions());
-
     console.log(`Building the following packages: ${PACKAGES}`);
     await exec.exec("colcon", ["build", "--build-base", "build", "--install-base", "install"], getWorkingDirExecOptions());
   } catch (error) {
@@ -193,13 +199,24 @@ async function build() {
 }
 
 async function bundle() {
-  try {
-    const bundleFilename = path.basename(WORKSPACE_DIRECTORY); 
-    await exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
-    await exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
-    await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
-  } catch (error) {
-    core.setFailed(error.message);
+  let delay_ms = 1000 * MINIMUM_BACKOFF_TIME_SECONDS; 
+  // indexed from 0 because COLCON_BUNDLE_RETRIES is the number of retries AFTER the initial try
+  for (let i = 0; i <= COLCON_BUNDLE_RETRIES; i++) {
+    try {
+      const bundleFilename = path.basename(WORKSPACE_DIRECTORY); 
+      await exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
+      await exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
+      break; // break if colcon bundle passes
+    } catch (error) {
+      if (i == COLCON_BUNDLE_RETRIES){
+        core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
+        break;
+      }
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle before retrying
+      await delay(delay_ms); // wait for next retry per the current exponential backoff delay
+      delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
+    }
   }
 }
 
@@ -208,6 +225,11 @@ async function run() {
   console.log(`GAZEBO_VERSION: ${GAZEBO_VERSION}`);
   console.log(`WORKSPACE_DIRECTORY: ${WORKSPACE_DIRECTORY}`);
   console.log(`GENERATE_SOURCES: ${GENERATE_SOURCES}`);
+  
+  // check if COLCON_BUNDLE_RETRIES is valid (i.e. 0<) and not too large (i.e. <10)  
+  if (COLCON_BUNDLE_RETRIES<0 || 9<COLCON_BUNDLE_RETRIES){
+    core.setFailed(`Invalid number of colcon bundle retries. Must be between 0-9 inclusive`);
+  }
 
   await setup();
   if (ROS_DISTRO == "kinetic" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "7")) {

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -209,11 +209,11 @@ async function bundle() {
       await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
       break; // break if colcon bundle passes
     } catch (error) {
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle assets
       if (i == COLCON_BUNDLE_RETRIES){
         core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
         break;
       }
-      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle before retrying
       await delay(delay_ms); // wait for next retry per the current exponential backoff delay
       delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding retry w/ exponential backoff to colcon bundle with min delay=32s and max delay=128s.

The retry to specifically added to `bundle`. If we want to re-use retry mechanism for other functions, it could be pulled out as a generic wrapper function/decorator.

*Testing:*
Changes are not yet tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
