### PR TITLE
Bump setup-node action version to 2.1.4(latest)

### DIFF
--- a/.github/workflows/test-ros2.yml
+++ b/.github/workflows/test-ros2.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         path: action    
     - name: Setup nodeJS
-      uses: actions/setup-node@v1.4.3
+      uses: actions/setup-node@v2.1.4
       with:
         node-version: '12.x'
     - name: Install nodeJS packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         path: action    
     - name: Setup nodeJS
-      uses: actions/setup-node@v1.4.3
+      uses: actions/setup-node@v2.1.4
       with:
         node-version: '12.x'
     - name: Install nodeJS packages


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump setup-node action version to 2.1.4(latest) due to https://github.com/actions/setup-node/issues/212.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
