### PR TITLE
Add colcon bundle retry

### DIFF
--- a/.github/workflows/test-ros2.yml
+++ b/.github/workflows/test-ros2.yml
@@ -70,7 +70,7 @@ jobs:
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:
         files: "./robot_ws.tar, ./robot_ws/build, ./robot_ws/install, ./robot_ws/src/deps"
         allow_failure: true
@@ -86,7 +86,7 @@ jobs:
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:
         files: "./simulation_ws.tar, ./simulation_ws/build, ./simulation_ws/install, ./simulation_ws/src/deps"
         allow_failure: true
@@ -94,7 +94,7 @@ jobs:
     # Expectation: source files exist    
     - name: Check source file existence
       id: check_source_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:        
         files: "./sources.zip, ./sources.tar.gz"
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:
         files: "./robot_ws.tar, ./robot_ws/build, ./robot_ws/install, ./robot_ws/src/deps"
         allow_failure: true
@@ -96,7 +96,7 @@ jobs:
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:
         files: "./simulation_ws.tar, ./simulation_ws/build, ./simulation_ws/install, ./simulation_ws/src/deps"
         allow_failure: true
@@ -104,7 +104,7 @@ jobs:
     # Expectation: source files exist    
     - name: Check source file existence
       id: check_source_files
-      uses: andstor/file-existence-action@87d74d4
+      uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
       with:        
         files: "./sources.zip, ./sources.tar.gz"
     

--- a/robomaker-sample-app-ci/action.yml
+++ b/robomaker-sample-app-ci/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Whether or not to generate sources.zip and sources.tar.gz files [true|false]'
     default: false
   colcon-bundle-retries:
-    description: 'Number of times colcon bundle should be re-tried with exponentail backoff in case of failure [0-9]'
+    description: 'Number of times colcon bundle should be re-tried with exponential backoff in case of failure [0-9]'
     default: 0
 
 outputs:

--- a/robomaker-sample-app-ci/action.yml
+++ b/robomaker-sample-app-ci/action.yml
@@ -13,6 +13,10 @@ inputs:
   generate-sources:
     description: 'Whether or not to generate sources.zip and sources.tar.gz files [true|false]'
     default: false
+  colcon-bundle-retries:
+    description: 'Number of times colcon bundle should be re-tried with exponentail backoff in case of failure [0-9]'
+    default: 0
+
 outputs:
   ros-distro:
     description: 'Distribution of ROS to use [kinetic|melodic|dashing]'

--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -674,6 +674,9 @@ const ROS_ENV_VARIABLES = {};
 const COLCON_BUNDLE_RETRIES = Number.parseInt(core.getInput('colcon-bundle-retries'), 10);
 const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
 const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
+function delay(ms: number) {
+    return new Promise( resolve => setTimeout(resolve, ms) );
+}
 function loadROSEnvVariables() {
     return __awaiter(this, void 0, void 0, function* () {
         const options = {
@@ -877,7 +880,6 @@ function bundle() {
         }
     });
 }
-
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`ROS_DISTRO: ${ROS_DISTRO}`);

--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -674,7 +674,7 @@ const ROS_ENV_VARIABLES = {};
 const COLCON_BUNDLE_RETRIES = Number.parseInt(core.getInput('colcon-bundle-retries'), 10);
 const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
 const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
-function delay(ms: number) {
+function delay(ms) {
     return new Promise( resolve => setTimeout(resolve, ms) );
 }
 function loadROSEnvVariables() {

--- a/robomaker-sample-app-ci/dist/index.js
+++ b/robomaker-sample-app-ci/dist/index.js
@@ -671,6 +671,9 @@ const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
 const GENERATE_SOURCES = core.getInput('generate-sources');
 let PACKAGES = "none";
 const ROS_ENV_VARIABLES = {};
+const COLCON_BUNDLE_RETRIES = Number.parseInt(core.getInput('colcon-bundle-retries'), 10);
+const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
+const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
 function loadROSEnvVariables() {
     return __awaiter(this, void 0, void 0, function* () {
         const options = {
@@ -852,23 +855,40 @@ function build() {
 }
 function bundle() {
     return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const bundleFilename = path.basename(WORKSPACE_DIRECTORY);
-            yield exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
-            yield exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
-            yield exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // github actions have been failing with no disk space
-        }
-        catch (error) {
-            core.setFailed(error.message);
+        let delay_ms = 1000 * MINIMUM_BACKOFF_TIME_SECONDS;
+        // indexed from 0 because COLCON_BUNDLE_RETRIES is the number of retries AFTER the initial try
+        for (let i = 0; i <= COLCON_BUNDLE_RETRIES; i++) {
+            try {
+                const bundleFilename = path.basename(WORKSPACE_DIRECTORY);
+                yield exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
+                yield exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
+                yield exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
+                break; // break if colcon bundle passes
+            } catch (error) {
+                yield exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle assets
+                if (i == COLCON_BUNDLE_RETRIES){
+                    core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
+                    break;
+                }
+                console.log(`Colcon bundle failed.. retrying in ${delay_ms} milliseconds`);
+                yield delay(delay_ms); // wait for next retry per the current exponential backoff delay
+                delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
+            }
         }
     });
 }
+
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`ROS_DISTRO: ${ROS_DISTRO}`);
         console.log(`GAZEBO_VERSION: ${GAZEBO_VERSION}`);
         console.log(`WORKSPACE_DIRECTORY: ${WORKSPACE_DIRECTORY}`);
         console.log(`GENERATE_SOURCES: ${GENERATE_SOURCES}`);
+        console.log(`COLCON_BUNDLE_RETRIES: ${COLCON_BUNDLE_RETRIES}`);
+        // check if COLCON_BUNDLE_RETRIES is valid (i.e. 0<) and not too large (i.e. <10)
+        if (COLCON_BUNDLE_RETRIES<0 || 9<COLCON_BUNDLE_RETRIES){
+            core.setFailed(`Invalid number of colcon bundle retries. Must be between 0-9 inclusive`);
+        }
         yield setup();
         if (ROS_DISTRO == "kinetic" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "7")) {
             GAZEBO_VERSION = "7";

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -203,7 +203,7 @@ async function bundle() {
   // indexed from 0 because COLCON_BUNDLE_RETRIES is the number of retries AFTER the initial try
   for (let i = 0; i <= COLCON_BUNDLE_RETRIES; i++) {
     try {
-      const bundleFilename = path.basename(WORKSPACE_DIRECTORY); 
+      const bundleFilename = path.basename(WORKSPACE_DIRECTORY);
       await exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
       await exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
       await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
@@ -214,6 +214,7 @@ async function bundle() {
         core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
         break;
       }
+      console.log(`Colcon bundle failed.. retrying in ${delay_ms} milliseconds`);
       await delay(delay_ms); // wait for next retry per the current exponential backoff delay
       delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
     }
@@ -225,6 +226,7 @@ async function run() {
   console.log(`GAZEBO_VERSION: ${GAZEBO_VERSION}`);
   console.log(`WORKSPACE_DIRECTORY: ${WORKSPACE_DIRECTORY}`);
   console.log(`GENERATE_SOURCES: ${GENERATE_SOURCES}`);
+  console.log(`COLCON_BUNDLE_RETRIES: ${COLCON_BUNDLE_RETRIES}`);
   
   // check if COLCON_BUNDLE_RETRIES is valid (i.e. 0<) and not too large (i.e. <10)  
   if (COLCON_BUNDLE_RETRIES<0 || 9<COLCON_BUNDLE_RETRIES){

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -12,6 +12,13 @@ const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
 const GENERATE_SOURCES = core.getInput('generate-sources');
 let PACKAGES = "none"
 const ROS_ENV_VARIABLES: any = {};
+let COLCON_BUNDLE_RETRIES = core.getInput('colcon-bundle-retries');
+const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
+const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
 
 async function loadROSEnvVariables() {
   const options = {
@@ -184,7 +191,6 @@ async function prepare_sources() {
 async function build() {
   try {
     await exec.exec("rosdep", ["install", "--from-paths", ".", "--ignore-src", "-r", "-y", "--rosdistro", ROS_DISTRO], getWorkingDirExecOptions());
-
     console.log(`Building the following packages: ${PACKAGES}`);
     await exec.exec("colcon", ["build", "--build-base", "build", "--install-base", "install"], getWorkingDirExecOptions());
   } catch (error) {
@@ -193,13 +199,24 @@ async function build() {
 }
 
 async function bundle() {
-  try {
-    const bundleFilename = path.basename(WORKSPACE_DIRECTORY); 
-    await exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
-    await exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
-    await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
-  } catch (error) {
-    core.setFailed(error.message);
+  let delay_ms = 1000 * MINIMUM_BACKOFF_TIME_SECONDS; 
+  // indexed from 0 because COLCON_BUNDLE_RETRIES is the number of retries AFTER the initial try
+  for (let i = 0; i <= COLCON_BUNDLE_RETRIES; i++) {
+    try {
+      const bundleFilename = path.basename(WORKSPACE_DIRECTORY); 
+      await exec.exec("colcon", ["bundle", "--build-base", "build", "--install-base", "install", "--bundle-base", "bundle"], getWorkingDirExecOptions());
+      await exec.exec("mv", ["bundle/output.tar", `../${bundleFilename}.tar`], getWorkingDirExecOptions());
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
+      break; // break if colcon bundle passes
+    } catch (error) {
+      if (i == COLCON_BUNDLE_RETRIES){
+        core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
+        break;
+      }
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle before retrying
+      await delay(delay_ms); // wait for next retry per the current exponential backoff delay
+      delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
+    }
   }
 }
 
@@ -208,6 +225,11 @@ async function run() {
   console.log(`GAZEBO_VERSION: ${GAZEBO_VERSION}`);
   console.log(`WORKSPACE_DIRECTORY: ${WORKSPACE_DIRECTORY}`);
   console.log(`GENERATE_SOURCES: ${GENERATE_SOURCES}`);
+  
+  // check if COLCON_BUNDLE_RETRIES is valid (i.e. 0<) and not too large (i.e. <10)  
+  if (COLCON_BUNDLE_RETRIES<0 || 9<COLCON_BUNDLE_RETRIES){
+    core.setFailed(`Invalid number of colcon bundle retries. Must be between 0-9 inclusive`);
+  }
 
   await setup();
   if (ROS_DISTRO == "kinetic" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "7")) {

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -12,7 +12,7 @@ const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
 const GENERATE_SOURCES = core.getInput('generate-sources');
 let PACKAGES = "none"
 const ROS_ENV_VARIABLES: any = {};
-let COLCON_BUNDLE_RETRIES = core.getInput('colcon-bundle-retries');
+const COLCON_BUNDLE_RETRIES = Number.parseInt(core.getInput('colcon-bundle-retries'), 10);
 const MINIMUM_BACKOFF_TIME_SECONDS = 32; // delay for the first retry in seconds
 const MAXIMUM_BACKOFF_TIME_SECONDS = 128; // maximum delay for a retry in seconds
 

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -209,11 +209,11 @@ async function bundle() {
       await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions());  // github actions have been failing with no disk space
       break; // break if colcon bundle passes
     } catch (error) {
+      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle assets
       if (i == COLCON_BUNDLE_RETRIES){
         core.setFailed(error.message); // set action to Failed if the colcon bundle fails even after COLCON_BUNDLE_RETRIES number of retries
         break;
       }
-      await exec.exec("rm", ["-rf", "bundle"], getWorkingDirExecOptions()); // remove erred bundle before retrying
       await delay(delay_ms); // wait for next retry per the current exponential backoff delay
       delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding retry w/ exponential backoff to colcon bundle with min delay=32s and max delay=128s.

The retry mechanism is only added to the `bundle` method. If we want to re-use the retry mechanism for other functions in future, it could be pulled out as a generic wrapper function/decorator.

*Testing:*
Changes are tested on personal helloworld and cloudwatch SA forks. The GH action workflows work as they used to before. 
[OUTSTANDING BEFORE MERGE] The efficacy of the retry mechanism is not tested because colcon bundle did not fail in the workflow runs that I could run. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
