### PR TITLE
support ros2 foxy

### DIFF
--- a/.github/workflows/test-ros2foxy.yml
+++ b/.github/workflows/test-ros2foxy.yml
@@ -17,12 +17,12 @@ jobs:
     
     strategy:      
       matrix:
-        distro: ['dashing']
-        gazebo: [9]
+        distro: ['foxy']
+        gazebo: [11]
         include:
-        - distro: dashing
-          gazebo: 9
-          ubuntu_distro: bionic
+        - distro: foxy
+          gazebo: 11
+          ubuntu_distro: focal
                
     container: 
       image: rostooling/setup-ros-docker:ubuntu-${{ matrix.ubuntu_distro }}-ros-${{ matrix.distro }}-ros-base-latest
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: aws-robotics/aws-robomaker-sample-application-helloworld
-        ref: ros2
+        ref: ros2_foxy
     # Checkout action code into action folder
     - name: Checkout action code
       uses: actions/checkout@v2

--- a/.github/workflows/test-ros2foxy.yml
+++ b/.github/workflows/test-ros2foxy.yml
@@ -68,7 +68,6 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./robot_ws
         generate-sources: true  
-        ubuntu-distro: ${{ matrix.ubuntu_distro }}
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
@@ -85,7 +84,6 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./simulation_ws
         generate-sources: false      
-        ubuntu-distro: ${{ matrix.ubuntu_distro }}  
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files

--- a/.github/workflows/test-ros2foxy.yml
+++ b/.github/workflows/test-ros2foxy.yml
@@ -68,6 +68,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./robot_ws
         generate-sources: true  
+        ubuntu-distro: ${{ matrix.ubuntu_distro }}
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
@@ -83,7 +84,8 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./simulation_ws
-        generate-sources: false        
+        generate-sources: false      
+        ubuntu-distro: ${{ matrix.ubuntu_distro }}  
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,7 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./robot_ws
-        generate-sources: true  
-        ubuntu-distro: ${{ matrix.ubuntu_distro }}
+        generate-sources: true
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
@@ -93,8 +92,7 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./simulation_ws
-        generate-sources: false    
-        ubuntu-distro: ${{ matrix.ubuntu_distro }}    
+        generate-sources: false
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./robot_ws
         generate-sources: true  
+        ubuntu-distro: ${{ matrix.ubuntu_distro }}
     # Expectation: bundle file, build files, and dependencies all exist
     - name: Check robot_ws file existence
       id: check_robot_ws_files
@@ -92,7 +93,8 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: ./simulation_ws
-        generate-sources: false        
+        generate-sources: false    
+        ubuntu-distro: ${{ matrix.ubuntu_distro }}    
     # Expectation: bundle file, build files, and dependencies all exist        
     - name: Check simulation_ws file existence
       id: check_simulation_ws_files

--- a/robomaker-sample-app-ci/README.md
+++ b/robomaker-sample-app-ci/README.md
@@ -1,7 +1,7 @@
 # AWS RoboMaker Sample Application CI Github Action
 
 This action will build and bundle your AWS RoboMaker Sample Application package.
-It must run in an environment that has all core ROS dependencies already installed for the ROS distro you are using (Kinetic, Melodic, Dashing, etc). 
+It must run in an environment that has all core ROS dependencies already installed for the ROS distro you are using (Kinetic, Melodic, Dashing, Foxy etc). 
 
 You use a [setup-ros-docker docker container], see usage section to see how to use this container. 
 
@@ -42,7 +42,7 @@ jobs:
 
 ### `ros-distro`
 
-**Required** Distribution of ROS you are using (`[kinetic|melodic|dashing]`)
+**Required** Distribution of ROS you are using (`[kinetic|melodic|dashing|foxy]`)
 
 ### `workspace-dir`
 

--- a/robomaker-sample-app-ci/action.yml
+++ b/robomaker-sample-app-ci/action.yml
@@ -2,10 +2,10 @@ name: 'aws-robomaker-sample-application-ci'
 description: 'Build and Bundle an AWS RoboMaker Sample Application Package'
 inputs:
   ros-distro:
-    description: 'Distribution of ROS to use [kinetic|melodic|dashing]'
+    description: 'Distribution of ROS to use [kinetic|melodic|dashing|foxy]'
     required: true
   gazebo-version:
-    description: 'Version of Gazebo to use [unspecified|7|9]'
+    description: 'Version of Gazebo to use [unspecified|7|9|11]'
     default: ''
   workspace-dir:
     description: 'Path to the workspace folder that contains your packages [robot_ws|simulation_ws]'
@@ -19,9 +19,9 @@ inputs:
 
 outputs:
   ros-distro:
-    description: 'Distribution of ROS to use [kinetic|melodic|dashing]'
+    description: 'Distribution of ROS to use [kinetic|melodic|dashing|foxy]'
   gazebo-version:
-    description: 'Version of Gazebo to use [gazebo7|gazebo9]'
+    description: 'Version of Gazebo to use [gazebo7|gazebo9|gazebo11]'
   sample-app-version:
     description: 'Version of the sample application that was built (from the package.xml)'
 runs:

--- a/robomaker-sample-app-ci/package.json
+++ b/robomaker-sample-app-ci/package.json
@@ -18,6 +18,7 @@
     "kinetic",
     "melodic",
     "dashing",
+    "foxy",
     "setup"
   ],
   "author": "AWS RoboMaker",

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -117,11 +117,15 @@ async function setup() {
       "lcov",
       "libgtest-dev",
       "python3-colcon-common-extensions",
-      "python3-pip",
       "python3-apt",
-      (UBUNTU_DISTRO == "focal") ? "python3-pip" : "python-pip",
+      "python3-pip",
+      (UBUNTU_DISTRO != "focal") && "python-pip",
       (UBUNTU_DISTRO == "focal") ? "python3-rosinstall" : "python-rosinstall",
     ];
+
+    if(UBUNTU_DISTRO == "focal"){
+      delete aptPackages[""]
+    }
 
     const python3Packages = [
       "setuptools",

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -6,6 +6,7 @@ import { ExecOptions } from '@actions/exec/lib/interfaces';
 const fs = require('fs');
 
 const ROS_DISTRO = core.getInput('ros-distro', {required: true});
+const UBUNTU_DISTRO = core.getInput('ubuntu-distro');
 let GAZEBO_VERSION = core.getInput('gazebo-version');
 let SAMPLE_APP_VERSION = '';
 const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
@@ -118,8 +119,8 @@ async function setup() {
       "python3-colcon-common-extensions",
       "python3-pip",
       "python3-apt",
-      (ROS_DISTRO == "foxy") ? "python3-pip" : "python-pip",
-      (ROS_DISTRO == "foxy") ? "python3-rosinstall" : "python-rosinstall",
+      (UBUNTU_DISTRO == "focal") ? "python3-pip" : "python-pip",
+      (UBUNTU_DISTRO == "focal") ? "python3-rosinstall" : "python-rosinstall",
     ];
 
     const python3Packages = [

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -111,7 +111,7 @@ async function setup() {
   try {
     await exec.exec("sudo", ["apt-key", "adv", "--fetch-keys", "http://packages.osrfoundation.org/gazebo.key"]);
 
-    const aptPackages = [
+    let aptPackages = [
       "zip",
       "cmake",
       "lcov",
@@ -119,9 +119,13 @@ async function setup() {
       "python3-colcon-common-extensions",
       "python3-apt",
       "python3-pip",
-      (UBUNTU_DISTRO != "focal") ? "python-pip" : "",
       (UBUNTU_DISTRO == "focal") ? "python3-rosinstall" : "python-rosinstall",
     ];
+
+    if(UBUNTU_DISTRO!="focal"){
+      //focal does not ship with python2 and does not require python-pip
+      aptPackages = aptPackages.concat(["python-pip"])
+    }
 
     const python3Packages = [
       "setuptools",

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -115,11 +115,11 @@ async function setup() {
       "cmake",
       "lcov",
       "libgtest-dev",
-      "python-pip",
-      "python-rosinstall",
       "python3-colcon-common-extensions",
       "python3-pip",
-      "python3-apt"
+      "python3-apt",
+      (ROS_DISTRO == "foxy") ? "python3-pip" : "python-pip",
+      (ROS_DISTRO == "foxy") ? "python3-rosinstall" : "python-rosinstall",
     ];
 
     const python3Packages = [
@@ -147,11 +147,11 @@ async function setup() {
   }
 }
 
-async function setup_gazebo9() {
+async function setup_gazebo_source() {
   try {
-    const gazebo9_apt_file = "/etc/apt/sources.list.d/gazebo-stable.list";
-    await exec.exec("sudo", ["rm", "-f", gazebo9_apt_file]);
-    await exec.exec("bash", ["-c", `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main" | sudo tee ${gazebo9_apt_file}`]);
+    const gazebo_apt_file = "/etc/apt/sources.list.d/gazebo-stable.list";
+    await exec.exec("sudo", ["rm", "-f", gazebo_apt_file]);
+    await exec.exec("bash", ["-c", `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main" | sudo tee ${gazebo_apt_file}`]);
     await exec.exec("sudo", ["apt-get", "update"]);
 
     if (ROS_DISTRO == "kinetic") {
@@ -237,13 +237,16 @@ async function run() {
   if (ROS_DISTRO == "kinetic" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "7")) {
     GAZEBO_VERSION = "7";
   } else if (ROS_DISTRO == "kinetic" && GAZEBO_VERSION == "9") {
-    await setup_gazebo9();
+    await setup_gazebo_source();
   } else if (ROS_DISTRO == "melodic" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "9")) {
     GAZEBO_VERSION = "9";
-    await setup_gazebo9();
+    await setup_gazebo_source();
   } else if (ROS_DISTRO == "dashing" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "9")) {
     GAZEBO_VERSION = "9";
-    await setup_gazebo9();
+    await setup_gazebo_source();
+  } else if (ROS_DISTRO == "foxy" && (GAZEBO_VERSION == "" || GAZEBO_VERSION == "11")) {
+    GAZEBO_VERSION = "11";
+    await setup_gazebo_source();
   } else {
     core.setFailed(`Invalid ROS and Gazebo combination`);
   }

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -119,13 +119,9 @@ async function setup() {
       "python3-colcon-common-extensions",
       "python3-apt",
       "python3-pip",
-      (UBUNTU_DISTRO != "focal") && "python-pip",
+      (UBUNTU_DISTRO != "focal") ? "python-pip" : "",
       (UBUNTU_DISTRO == "focal") ? "python3-rosinstall" : "python-rosinstall",
     ];
-
-    if(UBUNTU_DISTRO == "focal"){
-      delete aptPackages[""]
-    }
 
     const python3Packages = [
       "setuptools",

--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -6,7 +6,6 @@ import { ExecOptions } from '@actions/exec/lib/interfaces';
 const fs = require('fs');
 
 const ROS_DISTRO = core.getInput('ros-distro', {required: true});
-const UBUNTU_DISTRO = core.getInput('ubuntu-distro');
 let GAZEBO_VERSION = core.getInput('gazebo-version');
 let SAMPLE_APP_VERSION = '';
 const WORKSPACE_DIRECTORY = core.getInput('workspace-dir');
@@ -119,11 +118,13 @@ async function setup() {
       "python3-colcon-common-extensions",
       "python3-apt",
       "python3-pip",
-      (UBUNTU_DISTRO == "focal") ? "python3-rosinstall" : "python-rosinstall",
+      (ROS_DISTRO == "foxy") ? "python3-rosinstall" : "python-rosinstall",
     ];
 
-    if(UBUNTU_DISTRO!="focal"){
-      //focal does not ship with python2 and does not require python-pip
+    if(ROS_DISTRO!="foxy"){
+      //focal (foxy) does not ship with python2 and does not require python-pip
+      //using the ros_distro instead of ubuntu_distro saves users from specifying another 
+      //essentially redundant parameter.
       aptPackages = aptPackages.concat(["python-pip"])
     }
 


### PR DESCRIPTION
*Issue #, if available:*



*Description of changes:*
This change is to Support ROS2 Foxy, along Gazebo11 and Ubuntu Focal.  Ubuntu Focal does not ship with python2, and thus requires the python3 versions of python-pip and python-rosinstall.

The ubuntu-distro parameters defaults to an empty string, and thus would not break backward compatibility with any existing template.yml depending on this action.

The foxy and dashing branches of the sample applications will be kept as separate, so I have added a test-ros2foxy.yaml to test the new foxy branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
