### PR TITLE
Remove chown-step ROS2 workflow

### DIFF
--- a/.github/workflows/test-ros2.yml
+++ b/.github/workflows/test-ros2.yml
@@ -30,14 +30,7 @@ jobs:
     # NOTES: We run 2 tests for robot_ws and simulation_ws
     # The test steps are duplicated because github workflow does not support reusable step (with parameter yet)
     # We also can use matrix to run tests with different parameters but it is overkill for this
-    steps:    
-    - name: Setup permissions
-      run: |
-        # Due to user permisson issue, calling chown is necessary for now
-        # Related issue: https://github.com/actions/checkout/issues/47
-        # Note: rosbuild is the user of the docker image
-        # TODO(ros-tooling/setup-ros-docker#7): 
-        sudo chown -R rosbuild:rosbuild "$HOME" .         
+    steps:
     # Checkout SA ros2 branch into default root folder
     - name: Checkout hello world sample app
       uses: actions/checkout@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that https://github.com/actions/checkout/issues/47 is resolved, setting USER permissions is not required anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
