### PR TITLE
Update MAXIMUM_BACKOFF_TIME_SECONDS usage

### DIFF
--- a/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
+++ b/robomaker-sample-app-ci/src/aws-robomaker-sample-application-ci.ts
@@ -161,7 +161,7 @@ async function bundle() {
       }
       console.log(`Colcon bundle failed.. retrying in ${delay_ms} milliseconds`);
       await delay(delay_ms); // wait for next retry per the current exponential backoff delay
-      delay_ms = Math.min(delay_ms * 2, MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
+      delay_ms = Math.min(delay_ms * 2,  1000 * MAXIMUM_BACKOFF_TIME_SECONDS); // double the delay for the next retry, truncate if required
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Convert  MAXIMUM_BACKOFF_TIME_SECONDS to milliseconds before truncating the backoff time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
